### PR TITLE
New HTML/CSS Changes 

### DIFF
--- a/exocat/exocat.html
+++ b/exocat/exocat.html
@@ -24,8 +24,11 @@
                 on the <a href="https://github.com/spacetelescope/exocat">ExoCat
                 GitHub repository</a>, and our team will contact you as soon as
                 possible.
+                <br>
+                <br>
+                Link to download table: <a href="exocat_20210716.txt" download="exocat_table">txt</a>
                  </center>
-                <br /><br />
+                <br /><br /><br /><br />
                 <div align="center">
                      <input type="text" name="search" id="search" class="form-control" />
                 </div>
@@ -52,7 +55,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=11495&observatory=HST">11495</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-3b">WASP-3 / USNO-B1.01256-0285133</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-3b">WASP-3/USNO-B1.01256-0285133</a></td>
                           <td>18:34:31.6300</td>
                           <td>+35:39:41.52</td>
                           <td>G141</td>
@@ -70,7 +73,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=11495&observatory=HST">11495</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-3b">WASP-3 / USNO-B1.01256-0285133</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-3b">WASP-3/USNO-B1.01256-0285133</a></td>
                           <td>18:34:31.6300</td>
                           <td>+35:39:41.52</td>
                           <td>G141</td>
@@ -88,7 +91,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=11495&observatory=HST">11495</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-3b">WASP-3 / USNO-B1.01256-0285133</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-3b">WASP-3/USNO-B1.01256-0285133</a></td>
                           <td>18:34:31.6300</td>
                           <td>+35:39:41.52</td>
                           <td>G102</td>
@@ -1474,7 +1477,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13338&observatory=HST">13338</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436 / LHS-310</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436/LHS-310</a></td>
                           <td>11:42:11.0937</td>
                           <td>+26:42:23.65</td>
                           <td>G141</td>
@@ -1492,7 +1495,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13338&observatory=HST">13338</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436 / LHS-310</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436/LHS-310</a></td>
                           <td>11:42:11.0937</td>
                           <td>+26:42:23.65</td>
                           <td>G141</td>
@@ -1510,7 +1513,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13338&observatory=HST">13338</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436 / LHS-310</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436/LHS-310</a></td>
                           <td>11:42:11.0937</td>
                           <td>+26:42:23.65</td>
                           <td>G141</td>
@@ -1528,7 +1531,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13338&observatory=HST">13338</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436 / LHS-310</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436/LHS-310</a></td>
                           <td>11:42:11.0937</td>
                           <td>+26:42:23.65</td>
                           <td>G141</td>
@@ -1546,7 +1549,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13338&observatory=HST">13338</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436 / LHS-310</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436/LHS-310</a></td>
                           <td>11:42:11.0937</td>
                           <td>+26:42:23.65</td>
                           <td>G141</td>
@@ -1564,7 +1567,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13338&observatory=HST">13338</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436 / LHS-310</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436/LHS-310</a></td>
                           <td>11:42:11.0937</td>
                           <td>+26:42:23.65</td>
                           <td>G141</td>
@@ -1582,7 +1585,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13338&observatory=HST">13338</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436 / LHS-310</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436/LHS-310</a></td>
                           <td>11:42:11.0937</td>
                           <td>+26:42:23.65</td>
                           <td>G141</td>
@@ -1600,7 +1603,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13338&observatory=HST">13338</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436 / LHS-310</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ436b">GJ436/LHS-310</a></td>
                           <td>11:42:11.0937</td>
                           <td>+26:42:23.65</td>
                           <td>G141</td>
@@ -2734,7 +2737,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13665&observatory=HST">13665</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-138b">KEPLER-138 / 2MASS-J19213157+4317347</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-138b">KEPLER-138/2MASS-J19213157+4317347</a></td>
                           <td>19:21:31.5910</td>
                           <td>+43:17:34.79</td>
                           <td>G141</td>
@@ -2752,7 +2755,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13665&observatory=HST">13665</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-138b">KEPLER-138 / 2MASS-J19213157+4317347</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-138b">KEPLER-138/2MASS-J19213157+4317347</a></td>
                           <td>19:21:31.5910</td>
                           <td>+43:17:34.79</td>
                           <td>G141</td>
@@ -2770,7 +2773,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13665&observatory=HST">13665</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-138b">KEPLER-138 / 2MASS-J19213157+4317347</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-138b">KEPLER-138/2MASS-J19213157+4317347</a></td>
                           <td>19:21:31.5910</td>
                           <td>+43:17:34.79</td>
                           <td>G141</td>
@@ -2824,7 +2827,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13665&observatory=HST">13665</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=55-CANCRIb">55-CANCRI / GJ324A</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=55-CANCRIb">55-CANCRI/GJ324A</a></td>
                           <td>08:52:35.8109</td>
                           <td>+28:19:50.95</td>
                           <td>G141</td>
@@ -2842,7 +2845,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=13665&observatory=HST">13665</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=55-CANCRIb">55-CANCRI / GJ324A</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=55-CANCRIb">55-CANCRI/GJ324A</a></td>
                           <td>08:52:35.8109</td>
                           <td>+28:19:50.95</td>
                           <td>G141</td>
@@ -3004,7 +3007,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14099&observatory=HST">14099</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HAT-P-18b">HAT-P-18 / GSC-02594-00646</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HAT-P-18b">HAT-P-18/GSC-02594-00646</a></td>
                           <td>17:05:23.1510</td>
                           <td>+33:00:44.97</td>
                           <td>G141</td>
@@ -3058,7 +3061,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14169&observatory=HST">14169</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GSC-04980-00761b">GSC-04980-00761 / WASP-39</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GSC-04980-00761b">GSC-04980-00761/WASP-39</a></td>
                           <td>14:29:18.4080</td>
                           <td>-03:26:40.17</td>
                           <td>G102</td>
@@ -3850,7 +3853,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14455&observatory=HST">14455</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=EPIC-2037Bb">EPIC-2037B / 2MASSJ16101770-2459251</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=EPIC-2037Bb">EPIC-2037B/2MASSJ16101770-2459251</a></td>
                           <td>16:10:17.6900</td>
                           <td>-24:59:25.20</td>
                           <td>G141</td>
@@ -3868,7 +3871,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14468&observatory=HST">14468</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-121b">WASP-121 / 2MASSJ07102406-3905506</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-121b">WASP-121/2MASSJ07102406-3905506</a></td>
                           <td>07:10:24.0580</td>
                           <td>-39:05:50.55</td>
                           <td>G141</td>
@@ -3904,7 +3907,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14619&observatory=HST">14619</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-127b">WASP-127 / BD-03-2978</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-127b">WASP-127/BD-03-2978</a></td>
                           <td>10:42:14.0808</td>
                           <td>-03:50:06.26</td>
                           <td>G141</td>
@@ -4012,7 +4015,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4030,7 +4033,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4048,7 +4051,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4066,7 +4069,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4084,7 +4087,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4102,7 +4105,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-18b">K2-18/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4120,7 +4123,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4138,7 +4141,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4156,7 +4159,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4174,7 +4177,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4192,7 +4195,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4210,7 +4213,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4228,7 +4231,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14682&observatory=HST">14682</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3 / K2-18D</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=K2-3b">K2-3/K2-18D</a></td>
                           <td>11:30:14.5090</td>
                           <td>+07:35:18.21</td>
                           <td>G141</td>
@@ -4246,7 +4249,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14758&observatory=HST">14758</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281 / GJ1132</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281/GJ1132</a></td>
                           <td>10:14:51.7700</td>
                           <td>-47:09:24.10</td>
                           <td>G141</td>
@@ -4264,7 +4267,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14758&observatory=HST">14758</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281 / GJ1132</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281/GJ1132</a></td>
                           <td>10:14:51.7700</td>
                           <td>-47:09:24.10</td>
                           <td>G141</td>
@@ -4282,7 +4285,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14758&observatory=HST">14758</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281 / GJ1132</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281/GJ1132</a></td>
                           <td>10:14:51.7700</td>
                           <td>-47:09:24.10</td>
                           <td>G141</td>
@@ -4300,7 +4303,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14758&observatory=HST">14758</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281 / GJ1132</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281/GJ1132</a></td>
                           <td>10:14:51.7700</td>
                           <td>-47:09:24.10</td>
                           <td>G141</td>
@@ -4318,7 +4321,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14758&observatory=HST">14758</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281 / GJ1132</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=LHS-281b">LHS-281/GJ1132</a></td>
                           <td>10:14:51.7700</td>
                           <td>-47:09:24.10</td>
                           <td>G141</td>
@@ -4570,7 +4573,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=14767&observatory=HST">14767</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-121b">WASP-121 / 2MASSJ07102406-3905506</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=WASP-121b">WASP-121/2MASSJ07102406-3905506</a></td>
                           <td>07:10:24.0580</td>
                           <td>-39:05:50.55</td>
                           <td>G141</td>
@@ -5128,7 +5131,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15138&observatory=HST">15138</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-79b">KEPLER-79 / KIC8394721</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-79b">KEPLER-79/KIC8394721</a></td>
                           <td>20:02:04.1060</td>
                           <td>+44:22:53.60</td>
                           <td>G141</td>
@@ -5146,7 +5149,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15138&observatory=HST">15138</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-79b">KEPLER-79 / KIC8394721</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KEPLER-79b">KEPLER-79/KIC8394721</a></td>
                           <td>20:02:04.1060</td>
                           <td>+44:22:53.60</td>
                           <td>G141</td>
@@ -5164,7 +5167,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15149&observatory=HST">15149</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KIC-4760478b">KIC-4760478 / KEPLER-1625B</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KIC-4760478b">KIC-4760478/KEPLER-1625B</a></td>
                           <td>19:41:43.0430</td>
                           <td>+39:53:11.57</td>
                           <td>G141</td>
@@ -5182,7 +5185,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15149&observatory=HST">15149</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KIC-4760478b">KIC-4760478 / KEPLER-1625B</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=KIC-4760478b">KIC-4760478/KEPLER-1625B</a></td>
                           <td>19:41:43.0430</td>
                           <td>+39:53:11.57</td>
                           <td>G141</td>
@@ -5236,7 +5239,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15304&observatory=HST">15304</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J23062928-0502285b">2MASS-J23062928-0502285 / TRAPPIST-1</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J23062928-0502285b">2MASS-J23062928-0502285/TRAPPIST-1</a></td>
                           <td>23:06:30.3400</td>
                           <td>-05:02:36.44</td>
                           <td>G141</td>
@@ -5254,7 +5257,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15304&observatory=HST">15304</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J23062928-0502285b">2MASS-J23062928-0502285 / TRAPPIST-1</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J23062928-0502285b">2MASS-J23062928-0502285/TRAPPIST-1</a></td>
                           <td>23:06:30.3400</td>
                           <td>-05:02:36.44</td>
                           <td>G141</td>
@@ -5272,7 +5275,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15304&observatory=HST">15304</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J23062928-0502285b">2MASS-J23062928-0502285 / TRAPPIST-1</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J23062928-0502285b">2MASS-J23062928-0502285/TRAPPIST-1</a></td>
                           <td>23:06:30.3400</td>
                           <td>-05:02:36.44</td>
                           <td>G141</td>
@@ -5290,7 +5293,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15304&observatory=HST">15304</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J23062928-0502285b">2MASS-J23062928-0502285 / TRAPPIST-1</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J23062928-0502285b">2MASS-J23062928-0502285/TRAPPIST-1</a></td>
                           <td>23:06:30.3400</td>
                           <td>-05:02:36.44</td>
                           <td>G141</td>
@@ -5308,7 +5311,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5326,7 +5329,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5344,7 +5347,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5362,7 +5365,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5380,7 +5383,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5398,7 +5401,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5416,7 +5419,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-3167b">HD-3167/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5812,7 +5815,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=TOI674b">TOI674 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=TOI674b">TOI674/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5830,7 +5833,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=TOI674b">TOI674 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=TOI674b">TOI674/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5848,7 +5851,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15333&observatory=HST">15333</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=TOI674b">TOI674 / 2MASSJ10582099-3651292</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=TOI674b">TOI674/2MASSJ10582099-3651292</a></td>
                           <td>10:58:20.9947</td>
                           <td>-36:51:29.20</td>
                           <td>G141</td>
@@ -5866,7 +5869,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15428&observatory=HST">15428</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ-9827b">GJ-9827 / BD-02-5958</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ-9827b">GJ-9827/BD-02-5958</a></td>
                           <td>23:27:04.8365</td>
                           <td>-01:17:10.58</td>
                           <td>G141</td>
@@ -5884,7 +5887,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15428&observatory=HST">15428</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ-9827b">GJ-9827 / BD-02-5958</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ-9827b">GJ-9827/BD-02-5958</a></td>
                           <td>23:27:04.8365</td>
                           <td>-01:17:10.58</td>
                           <td>G141</td>
@@ -5902,7 +5905,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15428&observatory=HST">15428</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ-9827b">GJ-9827 / BD-02-5958</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=GJ-9827b">GJ-9827/BD-02-5958</a></td>
                           <td>23:27:04.8365</td>
                           <td>-01:17:10.58</td>
                           <td>G141</td>
@@ -5920,7 +5923,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15469&observatory=HST">15469</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J00041112-4721382b">2MASS-J00041112-4721382 / WASP-96</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J00041112-4721382b">2MASS-J00041112-4721382/WASP-96</a></td>
                           <td>00:04:11.1240</td>
                           <td>-47:21:38.25</td>
                           <td>G102</td>
@@ -5938,7 +5941,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15469&observatory=HST">15469</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J00041112-4721382b">2MASS-J00041112-4721382 / WASP-96</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J00041112-4721382b">2MASS-J00041112-4721382/WASP-96</a></td>
                           <td>00:04:11.1240</td>
                           <td>-47:21:38.25</td>
                           <td>G102</td>
@@ -5956,7 +5959,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15469&observatory=HST">15469</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J00041112-4721382b">2MASS-J00041112-4721382 / WASP-96</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=2MASS-J00041112-4721382b">2MASS-J00041112-4721382/WASP-96</a></td>
                           <td>00:04:11.1240</td>
                           <td>-47:21:38.25</td>
                           <td>G141</td>
@@ -5992,7 +5995,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6010,7 +6013,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6028,7 +6031,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6046,7 +6049,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6064,7 +6067,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6082,7 +6085,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6100,7 +6103,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6118,7 +6121,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6136,7 +6139,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6154,7 +6157,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6172,7 +6175,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6190,7 +6193,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6208,7 +6211,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6226,7 +6229,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6244,7 +6247,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6262,7 +6265,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6280,7 +6283,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6298,7 +6301,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6316,7 +6319,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6334,7 +6337,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6352,7 +6355,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6370,7 +6373,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6388,7 +6391,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6406,7 +6409,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6424,7 +6427,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6442,7 +6445,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6460,7 +6463,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6478,7 +6481,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6496,7 +6499,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6514,7 +6517,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -6532,7 +6535,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=15813&observatory=HST">15813</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458 / V-V376-PEG</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD209458b">HD209458/V-V376-PEG</a></td>
                           <td>22:03:10.8053</td>
                           <td>+18:53:03.27</td>
                           <td>G141</td>
@@ -7324,7 +7327,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=16220&observatory=HST">16220</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=AD3116b">AD3116 / EPIC-211946007</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=AD3116b">AD3116/EPIC-211946007</a></td>
                           <td>08:42:39.3997</td>
                           <td>+19:24:51.70</td>
                           <td>G141</td>
@@ -7414,7 +7417,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=16450&observatory=HST">16450</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-134004b">HD-134004 / KELT-26</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-134004b">HD-134004/KELT-26</a></td>
                           <td>15:09:04.8790</td>
                           <td>-42:42:17.88</td>
                           <td>G141</td>
@@ -7432,7 +7435,7 @@
                           </tr>
                           <tr>
                           <td><a href="https://www.stsci.edu/cgi-bin/get-proposal-info?id=16450&observatory=HST">16450</a></td>
-                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-134004b">HD-134004 / KELT-26</a></td>
+                          <td><a href="https://exo.mast.stsci.edu/exomast_planet.html?planet=HD-134004b">HD-134004/KELT-26</a></td>
                           <td>15:09:04.8790</td>
                           <td>-42:42:17.88</td>
                           <td>G102</td>

--- a/exocat/exocat.html
+++ b/exocat/exocat.html
@@ -13,10 +13,11 @@
                 <h2 align="center">The WFC3/IR Exoplanet Catalog</h2>
 
                 <center> Welcome to the WFC3 team's exoplanet catalog! This table
-                contains a history of submitted WFC3/IR programs for exoplanet
-                observations. Please use the search bar below to look
-                for targets that may have already been observed by a previous
-                program, or to check the status of your submitted program(s).
+                  contains observations of transiting exoplanets made with HST/WFC3
+                  in the infrared channel using the stare or spatial scan mode.
+                  Please use the search bar below to look for targets that may
+                  have already been observed by a previous program.
+                </table>
                 <br>
                 <br>
                 If you have any questions on the table, please submit an issue

--- a/exocat/exocat.html
+++ b/exocat/exocat.html
@@ -8,7 +8,7 @@
       </head>
       <body>
            <br /><br />
-           <div class="container" style="width:1000px;">
+           <div class="container" style="width:1500px;">
                 <center><img src="exocat-logo-2.png"></center>
                 <h2 align="center">The WFC3/IR Exoplanet Catalog</h2>
 


### PR DESCRIPTION
Now shows full width of table by default 

Will work through more of Nikolay's suggestions:

- Add option to download table as txt, csv?
- Keep header of column labels while searching
- Change descriptive text to "Welcome to the WFC3 team’s exoplanet catalog! This table contains observations of transiting exoplanets made with HST/WFC3 in the infrared channel using the stare or spatial scan mode. Please use the search bar below to look for targets that may have already been observed by a previous program."